### PR TITLE
Update action_planner.py

### DIFF
--- a/python/semantic_kernel/planners/action_planner/action_planner.py
+++ b/python/semantic_kernel/planners/action_planner/action_planner.py
@@ -148,11 +148,13 @@ class ActionPlanner:
             )
             plan = Plan(description=goal, function=function_ref)
 
-        for key, val in generated_plan["plan"]["parameters"].items():
-            logger.info(f"Parameter {key}: {val}")
-            if val:
-                plan.parameters[key] = str(val)
-                plan.state[key] = str(val)
+
+        if "parameters" in generated_plan['plan']:
+            for key, val in generated_plan["plan"]["parameters"].items():
+                logger.info(f"Parameter {key}: {val}")
+                if val:
+                    plan.parameters[key] = str(val)
+                    plan.state[key] = str(val)
 
         return plan
 


### PR DESCRIPTION
Solution to the issue: Python: Action Planner breaking when parameters are not explicitly given in the ask
https://github.com/microsoft/semantic-kernel/issues/5583

### Motivation and Context

  1. What problem does it solve? 
A. The action planner breaks when the user does not provide specific parameters in the ask/goal
  2. What scenario does it contribute to? 
A. In cases when user may not explicitly mention any parameters in the ask/goal
  3. If it fixes an open issue, please link to the issue here. 
A. It fixes the issue https://github.com/microsoft/semantic-kernel/issues/5583

### Description

Just adding an IF condition before iterating through the generated_plan variable to check if parameters are present or not does the job
